### PR TITLE
core: make the .desktop file use the hwinfo icon

### DIFF
--- a/assets/install/hyprsysteminfo.desktop
+++ b/assets/install/hyprsysteminfo.desktop
@@ -4,5 +4,6 @@ Name=System Info
 GenericName=System Information Application
 Comment=A system information app from the Hyprland project
 Exec=hyprsysteminfo
+Icon=hwinfo
 Terminal=false
 Type=Application


### PR DESCRIPTION
before
![immagine](https://github.com/user-attachments/assets/b65e05fd-7302-4bcd-8d09-c54b49ecb659)

after
![immagine](https://github.com/user-attachments/assets/db9e171f-6be8-4a22-8f93-da0ed88ef2f3)

