### PR TITLE
core: fix reported display resolutions when fractionally scaled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project(hsi VERSION ${VER} LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt6 6.5 REQUIRED COMPONENTS Widgets Quick QuickControls2)
+find_package(Qt6 6.5 REQUIRED COMPONENTS Widgets Quick QuickControls2 WaylandClient)
 find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(hyprutils REQUIRED IMPORTED_TARGET hyprutils)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ qt_add_executable(hyprsysteminfo
     util/Utils.cpp
     SystemInfo.cpp
     SystemIconProvider.cpp
+    WaylandScreen.cpp
 )
 
 qt_add_qml_module(hyprsysteminfo
@@ -11,4 +12,6 @@ qt_add_qml_module(hyprsysteminfo
     QML_FILES main.qml
 )
 
-target_link_libraries(hyprsysteminfo PRIVATE Qt6::Widgets Qt6::QuickControls2 PkgConfig::hyprutils)
+target_link_libraries(hyprsysteminfo PRIVATE
+    Qt6::Widgets Qt6::QuickControls2 Qt6::WaylandClientPrivate PkgConfig::hyprutils
+)

--- a/src/SystemInfo.cpp
+++ b/src/SystemInfo.cpp
@@ -1,4 +1,5 @@
 #include "SystemInfo.hpp"
+#include "WaylandScreen.hpp"
 #include "util/Utils.hpp"
 #include <qclipboard.h>
 #include <array>
@@ -190,9 +191,8 @@ CSystemInternals::CSystemInternals(QObject* parent) : QObject(parent) {
 
     {
         std::string screens;
-        for (auto* s : QGuiApplication::screens()) {
-            auto ratio = s->devicePixelRatio();
-            screens += std::format("{} ({}x{}), ", s->name().toStdString(), s->size().width() * ratio, s->size().height() * ratio);
+        for (const auto& s : SWaylandScreenInfo::enumerateScreens()) {
+            screens += std::format("{} ({}x{}), ", s.name.toStdString(), s.pixelSize.width(), s.pixelSize.height());
         }
 
         if (!screens.empty())

--- a/src/WaylandScreen.cpp
+++ b/src/WaylandScreen.cpp
@@ -1,0 +1,60 @@
+#include "WaylandScreen.hpp"
+
+#include <QtWaylandClient/private/qwayland-wayland.h>
+#include <QtWaylandClient/private/qwaylanddisplay_p.h>
+#include <QtWaylandClient/private/qwaylandintegration_p.h>
+#include <cstdint>
+#include <qcontainerfwd.h>
+#include <qsize.h>
+#include <qstringliteral.h>
+#include <qtclasshelpermacros.h>
+#include <vector>
+
+using namespace QtWaylandClient;
+
+class CWaylandScreen : public QtWayland::wl_output {
+  public:
+    explicit CWaylandScreen(QWaylandDisplay* display, uint32_t version, uint32_t id);
+    ~CWaylandScreen() override;
+    Q_DISABLE_COPY_MOVE(CWaylandScreen);
+    SWaylandScreenInfo info;
+
+  protected:
+    void output_mode(uint32_t flags, int32_t width, int32_t height, int32_t refresh) override;
+    void output_name(const QString& name) override;
+};
+
+std::vector<SWaylandScreenInfo> SWaylandScreenInfo::enumerateScreens() {
+    auto*                        display = QWaylandIntegration::instance()->display();
+
+    std::vector<CWaylandScreen*> screens;
+    for (const auto& global : display->globals()) {
+        if (global.interface == QStringLiteral("wl_output")) {
+            screens.emplace_back(new CWaylandScreen(display, global.version, global.id));
+        }
+    }
+
+    display->forceRoundTrip();
+
+    std::vector<SWaylandScreenInfo> info;
+    for (auto* screen : screens) {
+        info.push_back(screen->info);
+        delete screen;
+    }
+
+    return info;
+}
+
+CWaylandScreen::CWaylandScreen(QWaylandDisplay* display, uint32_t version, uint32_t id) : QtWayland::wl_output(display->wl_registry(), id, 4u) {}
+
+CWaylandScreen::~CWaylandScreen() {
+    release();
+}
+
+void CWaylandScreen::output_mode(uint32_t flags, int width, int height, int refresh) {
+    info.pixelSize = QSize(width, height);
+}
+
+void CWaylandScreen::output_name(const QString& name) {
+    info.name = name;
+}

--- a/src/WaylandScreen.hpp
+++ b/src/WaylandScreen.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <qcontainerfwd.h>
+#include <qsize.h>
+#include <qstring.h>
+#include <qcontainerfwd.h>
+#include <vector>
+
+struct SWaylandScreenInfo {
+    QString                                name;
+    QSize                                  pixelSize;
+
+    static std::vector<SWaylandScreenInfo> enumerateScreens();
+};


### PR DESCRIPTION
Fixes incorrect reported display sizes when fractional scaling is enabled.

Yes, enumerating outputs is actually required for this. Qt only exposes logical size, and while QWaylandScreen has a field for this, its private and I would rather us not get hit with ABI breaks.