### PR TITLE
core: fix en_US language enforcement in cmds

### DIFF
--- a/src/SystemInfo.cpp
+++ b/src/SystemInfo.cpp
@@ -25,7 +25,7 @@
 using namespace Hyprutils::String;
 
 CSystemInternals::CSystemInternals(QObject* parent) : QObject(parent) {
-    setenv("LANG", "en_US.UTF-8", true);
+    setenv("LC_ALL", "en_US.UTF-8", true);
 
     // gather data from os-release
     if (auto data = readFile("/etc/os-release")) {


### PR DESCRIPTION
Close #19 