### PR TITLE
Added fing_pkg for WaylandClientPrivate

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Qt6 REQUIRED COMPONENTS WaylandClientPrivate)
+
 qt_add_executable(hyprsysteminfo
     main.cpp
     util/Utils.cpp


### PR DESCRIPTION
On 6.10 RC-1 I get the error below

```
CMake Error at src/CMakeLists.txt:15 (target_link_libraries):
  Target "hyprsysteminfo" links to:

    Qt6::WaylandClientPrivate

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
```

With these changes I am able to build hyprsysteminfo but I am presented with this error

```
CMake Warning at /usr/lib64/qt6/lib/cmake/Qt6/QtPublicDependencyHelpers.cmake:335 (message):
  This project is using headers of the WaylandClientPrivate module and will
  therefore be tied to this specific Qt module build version.  Running this
  project against other versions of the Qt modules may crash at any arbitrary
  point.  This is not a bug, but a result of using Qt internals.  You have
  been warned!

  You can disable this warning by setting QT_NO_PRIVATE_MODULE_WARNING to ON.
Call Stack (most recent call first):
  /usr/lib64/qt6/lib/cmake/Qt6WaylandClientPrivate/Qt6WaylandClientPrivateConfig.cmake:58 (_qt_internal_show_private_module_warning)
  /usr/lib64/qt6/lib/cmake/Qt6/Qt6Config.cmake:243 (find_package)
  src/CMakeLists.txt:1 (find_package)
```

Please review.