### PR TITLE
Conditionally include Qt6 WaylandClientPrivate package

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,6 @@
-find_package(Qt6 REQUIRED COMPONENTS WaylandClientPrivate)
+if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10) 
+  find_package(Qt6 REQUIRED COMPONENTS WaylandClientPrivate)
+endif()
 
 qt_add_executable(hyprsysteminfo
     main.cpp


### PR DESCRIPTION
in Qt 6.10 the wayland client private component was split into its own component.